### PR TITLE
fix: install http-server in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM node:lts-alpine
-
+FROM node:18-alpine3.17 AS build
 WORKDIR /app
-
-COPY ./package*.json ./
+COPY ./ /app
 
 RUN npm install
+RUN npm run build
 
-COPY ./ .
 
-EXPOSE 3002
+FROM node:lts-alpine
+COPY ./package*.json ./
+COPY --from=build /app/dist dist
+RUN npm install -g http-server
 
-CMD [ "npm", "run", "dev" ]
+EXPOSE 3004
+
+CMD [ "npm", "start" ]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "http-server dist -p 3004"
   },
   "dependencies": {
     "axios": "^1.7.9",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vitejs.dev/config/
 export default defineConfig({
   server: {
     host: '0.0.0.0',


### PR DESCRIPTION
We would use http-server inside container to serve the dist folder which would have the prod build of the website instead of running from src files.